### PR TITLE
Add support for customizing links between virtual instance switch and its containers

### DIFF
--- a/fogbed/experiment/distributed.py
+++ b/fogbed/experiment/distributed.py
@@ -51,7 +51,7 @@ class FogbedDistributedExperiment(Experiment):
             if(self.is_running):
                 worker = self._get_worker_by_datacenter(datacenter)
                 worker.net.add_docker(container.name, **container.params)
-                worker.net.add_link(container.name, datacenter.switch)
+                worker.net.add_link(container.name, datacenter.switch, **container.link_params)
                 worker.net.config_default(container.name)
                 service = RemoteDocker(container.name, worker.net.url)
                 container.set_docker(service)

--- a/fogbed/experiment/local.py
+++ b/fogbed/experiment/local.py
@@ -63,11 +63,11 @@ class FogbedExperiment(Experiment):
             info(f'{container.name}: Allocation of container was blocked by resource model.\n\n')
         else:
             self.topology.addHost(container.name, cls=Docker, **container.params)
-            self.topology.addLink(container.name, datacenter.switch)
+            self.topology.addLink(container.name, datacenter.switch, **container.link_params)
 
             if(self.net.is_running):
                 self.net.addDocker(container.name, **container.params)
-                self.net.addLink(container.name, datacenter.switch)
+                self.net.addLink(container.name, datacenter.switch, **container.link_params)
                 docker = self.net.getDocker(container.name)
                 docker.configDefault()
                 container.set_docker(LocalDocker(docker))

--- a/fogbed/node/container.py
+++ b/fogbed/node/container.py
@@ -29,9 +29,9 @@ class Container:
         self.ports       = list(self.bindings.keys())
         self.volumes     = volumes.copy()
         self.resources   = resources
+        self.link_params = link_params.copy()
         self._params     = params
         self._service: Optional[DockerService] = None
-        self.link_params = link_params
     
 
     def cmd(self, command: str) -> str:

--- a/fogbed/node/container.py
+++ b/fogbed/node/container.py
@@ -17,6 +17,7 @@ class Container:
         port_bindings: Dict[int, int] = {},
         volumes: List[str] = [],
         resources: HardwareResources = Resources.SMALL,
+        link_params: Dict[str, Any] = {},
         **params: Any
     ):
         self.name        = name
@@ -30,6 +31,7 @@ class Container:
         self.resources   = resources
         self._params     = params
         self._service: Optional[DockerService] = None
+        self.link_params = link_params
     
 
     def cmd(self, command: str) -> str:

--- a/fogbed/node/worker.py
+++ b/fogbed/node/worker.py
@@ -55,7 +55,7 @@ class Worker:
 
             for container in datacenter:
                 self.net.add_docker(container.name, **container.params)
-                self.net.add_link(container.name, datacenter.switch)
+                self.net.add_link(container.name, datacenter.switch, **container.link_params)
                 service = RemoteDocker(container.name, self.net.url)
                 container.set_docker(service)
 


### PR DESCRIPTION
This PR introduces support for a new property, `link_params`, in **Container** definitions. The goal is to enable fine-grained control over the link characteristics between an instance’s internal switch and its associated containers.

Currently, users can define `link_params` only for connections between different virtual instances. However, the internal links between a virtual instance’s switch and its containers are created without parameters.