### PR TITLE
Add support for running Fogbed commands on Ubuntu 22.04 or later

### DIFF
--- a/docs/config_files.md
+++ b/docs/config_files.md
@@ -78,7 +78,7 @@ fogbed run topology.yml
     Make sure the IP addresses and ports are configured according to the experiment script
     and run a worker in each machine with:
     ```
-    fogbed worker
+    fogbed worker -p=5000
     ```
 
 ## Using the ExperimentBuilder

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ Fogbed is a framework and toolset integration designed for rapid prototyping of 
 * [Python 3.8+](https://www.python.org/)
 
 
-## Install on Ubuntu 20.04
-
+## Install
+### Ubuntu 20.04
 === "Latest"
     Install Fogbed
     ```
@@ -40,3 +40,21 @@ Fogbed is a framework and toolset integration designed for rapid prototyping of 
     ```
     sudo pip install fogbed
     ```
+
+### Ubuntu 22.04 or Later
+Create and activate a virtual environment:
+```
+python3 -m venv venv
+```
+```
+source venv/bin/activate
+```
+
+Install Fogbed
+```
+pip install fogbed
+```
+Install Containernet
+```
+fogbed install 
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,12 @@
 Fogbed is a framework and toolset integration designed for rapid prototyping of fog components in virtualized environments using a desktop approach. It aims to meet the requirements of low cost, flexible setup, and compatibility with real-world technologies. The components are built upon the Mininet network emulator, leveraging Docker container instances as fog virtual nodes.
 
 ## Requirements
-* [Ubuntu 20.04](https://releases.ubuntu.com/focal/)
+* [Ubuntu 20.04 or later](https://releases.ubuntu.com/focal/)
 * [Containernet](https://containernet.github.io/)
 * [Python 3.8+](https://www.python.org/)
 
 
-## Install
+## Install on Ubuntu 20.04
 
 === "Latest"
     Install Fogbed

--- a/fogbed/helpers.py
+++ b/fogbed/helpers.py
@@ -13,6 +13,10 @@ def get_ip_address() -> str:
     output = subprocess.check_output(['hostname', '--all-ip-addresses'], text=True)
     return output.split(' ')[0]
 
+def get_os_version() -> str:
+    distro = subprocess.run(['lsb_release', '-irs'], capture_output=True, text=True)
+    return distro.stdout.replace('\n', '')
+
 def start_openflow_controller(ip: str, port: int):
     hostname = socket.gethostname()
     code = subprocess.call(['controller', '-D', f'ptcp:{port}'])
@@ -20,9 +24,15 @@ def start_openflow_controller(ip: str, port: int):
     if(code == 0):
         print(f'[{hostname}]: OpenFlow controller listening on: {ip}:{port}')
 
-
 def run_command(commands: List[str]):
     subprocess.call(commands)
+
+def run_python_file(filename: str):
+    if(get_os_version() == 'Ubuntu20.04'):
+        run_command(['sudo', 'python3', filename])
+    else:
+        run_command(['./venv/bin/python3', filename])
+
 
 def get_experiment_template_code(filename: str) -> str:
     return f'''

--- a/fogbed/helpers.py
+++ b/fogbed/helpers.py
@@ -38,7 +38,7 @@ def run_python_file(filename: str):
     if(get_os_version() == UBUNTU_2004):
         run_command(['sudo', 'python3', filename])
     else:
-        run_command(['./venv/bin/python3', filename])
+        run_command(['sudo', './venv/bin/python3', filename])
 
 
 def get_experiment_template_code(filename: str) -> str:

--- a/fogbed/helpers.py
+++ b/fogbed/helpers.py
@@ -2,6 +2,7 @@ import socket
 import subprocess
 from typing import List
 
+UBUNTU_2004 = 'Ubuntu20.04'
 
 def resolve_ip(ip: str) -> str:
     return socket.gethostbyname(ip)
@@ -27,8 +28,14 @@ def start_openflow_controller(ip: str, port: int):
 def run_command(commands: List[str]):
     subprocess.call(commands)
 
+def run_pip_install(package: str):
+    if(get_os_version() == UBUNTU_2004):
+        run_command(['sudo', 'pip', 'install', package])
+    else:
+        run_command(['pip', 'install', package])
+
 def run_python_file(filename: str):
-    if(get_os_version() == 'Ubuntu20.04'):
+    if(get_os_version() == UBUNTU_2004):
         run_command(['sudo', 'python3', filename])
     else:
         run_command(['./venv/bin/python3', filename])

--- a/fogbed/helpers.py
+++ b/fogbed/helpers.py
@@ -1,5 +1,6 @@
 import socket
 import subprocess
+import sys
 from typing import List
 
 UBUNTU_2004 = 'Ubuntu20.04'
@@ -35,10 +36,7 @@ def run_pip_install(package: str):
         run_command(['pip', 'install', package])
 
 def run_python_file(filename: str):
-    if(get_os_version() == UBUNTU_2004):
-        run_command(['sudo', 'python3', filename])
-    else:
-        run_command(['sudo', './venv/bin/python3', filename])
+    run_command(['sudo', sys.executable, filename])
 
 
 def get_experiment_template_code(filename: str) -> str:

--- a/fogbed/scripts.py
+++ b/fogbed/scripts.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pathlib import Path
 import tempfile
 
 from fogbed.helpers import (
@@ -32,7 +33,7 @@ def build(filename: str):
 def install_containernet(branch: str):
     print('Installing Containernet...')
     unzipped_folder = f'containernet-{branch}'
-    containernet_folder = 'containernet'
+    containernet_folder = os.path.join(Path.home(), 'containernet')
 
     run_command(['sudo', 'apt-get', 'install', 'ansible'])
     run_command(

--- a/fogbed/scripts.py
+++ b/fogbed/scripts.py
@@ -3,9 +3,11 @@ import os
 import tempfile
 
 from fogbed.helpers import (
+    UBUNTU_2004,
     get_experiment_template_code,
     get_os_version,
     run_command,
+    run_pip_install,
     run_python_file
 )
 
@@ -43,12 +45,12 @@ def install_containernet(branch: str):
         '-i', '"localhost,"', 
         '-c', 'local',
         f'{containernet_folder}/ansible/install.yml'])
-    run_command(['sudo', 'pip', 'install', 'git+https://github.com/containernet/containernet.git'])
     run_command(['rm', '-rf', f'{branch}.zip'])
+    run_pip_install('git+https://github.com/containernet/containernet.git')
 
 
 def run_worker(port: int):
-    if(get_os_version() == 'Ubuntu20.04'):
+    if(get_os_version() == UBUNTU_2004):
         run_command(['sudo', 'RunWorker', f'-p={port}'])
     else:
         run_command(['sudo', './venv/bin/RunWorker', f'-p={port}'])

--- a/fogbed/scripts.py
+++ b/fogbed/scripts.py
@@ -5,9 +5,7 @@ import tempfile
 import sys
 
 from fogbed.helpers import (
-    UBUNTU_2004,
     get_experiment_template_code,
-    get_os_version,
     run_command,
     run_pip_install,
     run_python_file
@@ -52,10 +50,8 @@ def install_containernet(branch: str):
 
 
 def run_worker(port: int):
-    if(get_os_version() == UBUNTU_2004):
-        run_command(['sudo', 'RunWorker', f'-p={port}'])
-    else:
-        run_command(['sudo', './venv/bin/RunWorker', f'-p={port}'])
+    run_worker_path = os.path.join(sys.prefix, 'bin', 'RunWorker')
+    run_command(['sudo', run_worker_path, f'-p={port}'])
 
 
 def main():

--- a/fogbed/scripts.py
+++ b/fogbed/scripts.py
@@ -4,13 +4,15 @@ import tempfile
 
 from fogbed.helpers import (
     get_experiment_template_code,
-    run_command
+    get_os_version,
+    run_command,
+    run_python_file
 )
 
 
 def build(filename: str):
     if(filename.endswith('.py')):
-        run_command(['sudo', 'python3', filename])
+        run_python_file(filename)
         return
     
     code = get_experiment_template_code(filename=os.path.abspath(filename))
@@ -20,7 +22,7 @@ def build(filename: str):
         temp_filename = file.name
     
     try:
-        run_command(['sudo', 'python3', temp_filename])
+        run_python_file(temp_filename)
     finally:
         os.remove(temp_filename)
 
@@ -35,20 +37,21 @@ def install_containernet(branch: str):
         ['wget', f'https://github.com/containernet/containernet/archive/refs/heads/{branch}.zip'])
     run_command(['unzip', f'{branch}.zip'])
     run_command(['mv', unzipped_folder, containernet_folder])
-
     run_command([
         'sudo', 
         'ansible-playbook', 
         '-i', '"localhost,"', 
         '-c', 'local',
         f'{containernet_folder}/ansible/install.yml'])
-    
     run_command(['sudo', 'pip', 'install', 'git+https://github.com/containernet/containernet.git'])
     run_command(['rm', '-rf', f'{branch}.zip'])
 
 
 def run_worker(port: int):
-    run_command(['sudo', 'RunWorker', f'-p={port}'])
+    if(get_os_version() == 'Ubuntu20.04'):
+        run_command(['sudo', 'RunWorker', f'-p={port}'])
+    else:
+        run_command(['sudo', './venv/bin/RunWorker', f'-p={port}'])
 
 
 def main():

--- a/fogbed/scripts.py
+++ b/fogbed/scripts.py
@@ -5,7 +5,9 @@ import tempfile
 import sys
 
 from fogbed.helpers import (
+    UBUNTU_2004,
     get_experiment_template_code,
+    get_os_version,
     run_command,
     run_pip_install,
     run_python_file
@@ -51,6 +53,8 @@ def install_containernet(branch: str):
 
 def run_worker(port: int):
     run_worker_path = os.path.join(sys.prefix, 'bin', 'RunWorker')
+    if(get_os_version() == UBUNTU_2004):
+        run_worker_path = 'RunWorker'
     run_command(['sudo', run_worker_path, f'-p={port}'])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Fog computing emulation platform."
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "clusternet >= 0.9.2",
+  "clusternet >= 0.9.3",
   "urllib3 >= 1.26.0"
 ]
 keywords = ["networking", "emulator", "protocol", "Internet", "OpenFlow", "SDN", "fog"]
@@ -29,4 +29,4 @@ classifiers = [
 fogbed = "fogbed.scripts:main"
 
 [project.urls]
-Homepage = "https://github.com/EsauM10/fogbed"
+Homepage = "https://larsid.github.io/fogbed"

--- a/tests/distributed.py
+++ b/tests/distributed.py
@@ -35,7 +35,7 @@ except Exception as ex:
 finally:
     exp.stop()
 
-# Run a Worker with: sudo RunWorker
+# Run a Worker with: fogbed worker -p=5000
 # Change the Worker IP with your machine ip adddress
 #    ex: worker1 = exp.add_worker(ip='192.168.0.185', port=5000)
-# Run this example with: sudo python3 tests/distributed.py
+# Run this example with: fogbed run tests/distributed.py

--- a/tests/distributed_metrics_enabled.py
+++ b/tests/distributed_metrics_enabled.py
@@ -36,7 +36,7 @@ except Exception as ex:
 finally:
     exp.stop()
 
-# Run a Worker with: sudo RunWorker
+# Run a Worker with: fogbed worker -p=5000
 # Change the Worker IP with your machine ip adddress
 #    ex: worker1 = exp.add_worker(ip='192.168.0.185', port=5000)
-# Run this example with: sudo python3 tests/distributed_metrics_enabled.py 
+# Run this example with: fogbed run tests/distributed_metrics_enabled.py 

--- a/tests/local.py
+++ b/tests/local.py
@@ -30,4 +30,4 @@ except Exception as ex:
 finally:
     exp.stop()
 
-# Run with: sudo python3 tests/local.py 
+# Run with: fogbed run tests/local.py 

--- a/tests/local_metrics_enabled.py
+++ b/tests/local_metrics_enabled.py
@@ -31,4 +31,4 @@ except Exception as ex:
 finally:
     exp.stop()
 
-# Run with: sudo python3 tests/local_metrics_enabled.py
+# Run with: fogbed run tests/local_metrics_enabled.py

--- a/tests/local_with_topology_file.py
+++ b/tests/local_with_topology_file.py
@@ -14,4 +14,4 @@ except Exception as ex:
 finally:
     exp.stop()
 
-# Run with: sudo python3 tests/local_with_topology_file.py
+# Run with: fogbed run tests/local_with_topology_file.py


### PR DESCRIPTION
This MR enables the execution of Fogbed commands (`run`, `install`, `worker`) on newer Ubuntu versions, such as Ubuntu 22.04 or later.

Users can now choose the installation mode of Fogbed and its dependencies according to the operating system by using the `fogbed install` command.

Additionally, the `fogbed run` and `fogbed worker` commands are now compatible with the latest Ubuntu versions, as long as Fogbed is installed within a virtual environment.

## Installation Instructions
### Ubuntu 20.04
Install Fogbed
```
sudo pip install fogbed
```
Install Containernet
```
fogbed install
```

### Ubuntu 22.04 or Later
Create and activate a virtual environment:
```
python3 -m venv venv
```
```
source venv/bin/activate
```
Install Fogbed and Containernet inside virtual env
```
pip install fogbed
```
```
fogbed install
```

